### PR TITLE
feat: add sqlx support for FixedBytes (ruint-style); update wrap_fixed_bytes macro and core-sol test compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,4 +103,4 @@ ruint-macro = { version = "1", default-features = false }
 winnow = { version = "0.7", default-features = false, features = ["alloc"] }
 
 # sqlx support (optional, for DB integration)
-sqlx = { version = "0.8", default-features = false}
+sqlx-core = { version = "0.8"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,3 +101,6 @@ rayon = { version = "1.2", default-features = false }
 ruint = { version = "1.14.0", default-features = false, features = ["alloc"] }
 ruint-macro = { version = "1", default-features = false }
 winnow = { version = "0.7", default-features = false, features = ["alloc"] }
+
+# sqlx support (optional, for DB integration)
+sqlx = { version = "0.8", default-features = false}

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -98,7 +98,7 @@ postgres-types = { workspace = true, optional = true }
 diesel = { workspace = true, optional = true }
 
 # sqlx support (optional, for DB integration)
-sqlx = { workspace = true, optional = true }
+sqlx-core = { workspace = true, optional = true }
 
 [dev-dependencies]
 bcs.workspace = true
@@ -156,7 +156,7 @@ serde = [
     "indexmap?/serde",
     "rand?/serde",
 ]
-sqlx = ["std", "sqlx/mysql", "sqlx/sqlite", "sqlx/postgres"]
+sqlx = ["dep:sqlx-core"]
 
 allocative = ["dep:allocative"]
 arbitrary = [

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -156,7 +156,7 @@ serde = [
     "indexmap?/serde",
     "rand?/serde",
 ]
-sqlx = ["dep:sqlx-core"]
+
 
 allocative = ["dep:allocative"]
 arbitrary = [
@@ -171,6 +171,7 @@ arbitrary = [
 ]
 postgres = ["std", "dep:postgres-types", "ruint/postgres"]
 diesel = ["std", "dep:diesel", "ruint/diesel"]
+sqlx = ["std","dep:sqlx-core","ruint/sqlx"]
 
 # `const-hex` compatibility feature for `hex`.
 # Should not be needed most of the time.

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -97,6 +97,9 @@ postgres-types = { workspace = true, optional = true }
 # diesel
 diesel = { workspace = true, optional = true }
 
+# sqlx support (optional, for DB integration)
+sqlx = { workspace = true, optional = true }
+
 [dev-dependencies]
 bcs.workspace = true
 bincode.workspace = true
@@ -153,6 +156,7 @@ serde = [
     "indexmap?/serde",
     "rand?/serde",
 ]
+sqlx = ["sqlx/mysql", "sqlx/sqlite", "sqlx/postgres"]
 
 allocative = ["dep:allocative"]
 arbitrary = [

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -156,7 +156,7 @@ serde = [
     "indexmap?/serde",
     "rand?/serde",
 ]
-sqlx = ["sqlx/mysql", "sqlx/sqlite", "sqlx/postgres"]
+sqlx = ["std", "sqlx/mysql", "sqlx/sqlite", "sqlx/postgres"]
 
 allocative = ["dep:allocative"]
 arbitrary = [

--- a/crates/primitives/src/bits/macros.rs
+++ b/crates/primitives/src/bits/macros.rs
@@ -233,6 +233,7 @@ macro_rules! wrap_fixed_bytes {
         $crate::impl_arbitrary!($name, $n);
         $crate::impl_rand!($name);
         $crate::impl_diesel!($name, $n);
+        $crate::impl_sqlx!($name, $n);
 
         impl $name {
             /// Array of Zero bytes.
@@ -854,6 +855,71 @@ macro_rules! impl_diesel {
 #[macro_export]
 #[cfg(not(feature = "diesel"))]
 macro_rules! impl_diesel {
+    ($t:ty, $n:literal) => {};
+}
+
+#[doc(hidden)]
+#[macro_export]
+#[cfg(feature = "sqlx")]
+macro_rules! impl_sqlx {
+    ($t:ty, $n:literal) => {
+        const _: () = {
+            #[cfg(not(feature = "std"))]
+            use alloc::vec::Vec;
+            #[cfg(feature = "std")]
+            use std::vec::Vec;
+            use $crate::private::sqlx_core::{
+                database::Database,
+                decode::Decode,
+                encode::{Encode, IsNull},
+                error::BoxDynError,
+                types::Type,
+            };
+
+            impl<DB> Type<DB> for $t
+            where
+                DB: Database,
+                Vec<u8>: Type<DB>,
+            {
+                fn type_info() -> <DB as Database>::TypeInfo {
+                    <$crate::FixedBytes<$n> as Type<DB>>::type_info()
+                }
+
+                fn compatible(ty: &<DB as Database>::TypeInfo) -> bool {
+                    <$crate::FixedBytes<$n> as Type<DB>>::compatible(ty)
+                }
+            }
+
+            impl<'a, DB> Encode<'a, DB> for $t
+            where
+                DB: Database,
+                Vec<u8>: Encode<'a, DB>,
+            {
+                fn encode_by_ref(
+                    &self,
+                    buf: &mut <DB as Database>::ArgumentBuffer<'a>,
+                ) -> Result<IsNull, BoxDynError> {
+                    <$crate::FixedBytes<$n> as Encode<DB>>::encode_by_ref(&self.0, buf)
+                }
+            }
+
+            impl<'a, DB> Decode<'a, DB> for $t
+            where
+                DB: Database,
+                Vec<u8>: Decode<'a, DB>,
+            {
+                fn decode(value: <DB as Database>::ValueRef<'a>) -> Result<Self, BoxDynError> {
+                    <$crate::FixedBytes<$n> as Decode<DB>>::decode(value).map(Self)
+                }
+            }
+        };
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+#[cfg(not(feature = "sqlx"))]
+macro_rules! impl_sqlx {
     ($t:ty, $n:literal) => {};
 }
 

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -129,4 +129,7 @@ pub mod private {
 
     #[cfg(feature = "diesel")]
     pub use diesel;
+
+    #[cfg(feature = "sqlx")]
+    pub use sqlx_core;
 }

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -22,6 +22,9 @@ pub mod postgres;
 #[cfg(feature = "diesel")]
 pub mod diesel;
 
+#[cfg(feature = "sqlx")]
+pub mod sqlx;
+
 pub mod aliases;
 #[doc(no_inline)]
 pub use aliases::{

--- a/crates/primitives/src/sqlx.rs
+++ b/crates/primitives/src/sqlx.rs
@@ -1,133 +1,55 @@
 //! Support for the [`sqlx`](https://crates.io/crates/sqlx) crate.
 //!
-//! Implements SQLx traits for [`Address`], allowing seamless integration with MySQL, PostgreSQL,
-//! and SQLite.
+//! Currently only encodes to/from a big-endian byte array.
+//!
+//! **Note:** The database column type must be `BINARY(20)` (MySQL/SQLite), `BYTEA` (Postgres), or
+//! equivalent binary type for correct Address roundtrip.
+
+#![cfg_attr(docsrs, doc(cfg(feature = "sqlx")))]
+
+use alloc::{boxed::Box, vec::Vec};
+
+use sqlx_core::{
+    database::Database,
+    decode::Decode,
+    encode::{Encode, IsNull},
+    error::BoxDynError,
+    types::Type,
+};
 
 use crate::Address;
-use core::str::FromStr;
 
-mod sqlx_impl {
-    use super::*;
-
-    // MySQL
-    impl sqlx::Type<sqlx::MySql> for Address {
-        fn type_info() -> sqlx::mysql::MySqlTypeInfo {
-            <String as sqlx::Type<sqlx::MySql>>::type_info()
-        }
-        fn compatible(ty: &sqlx::mysql::MySqlTypeInfo) -> bool {
-            <String as sqlx::Type<sqlx::MySql>>::compatible(ty)
-        }
+impl<DB: Database> Type<DB> for Address
+where
+    Vec<u8>: Type<DB>,
+{
+    fn type_info() -> DB::TypeInfo {
+        <Vec<u8> as Type<DB>>::type_info()
     }
 
-    impl<'r> sqlx::Decode<'r, sqlx::MySql> for Address {
-        fn decode(
-            value: sqlx::mysql::MySqlValueRef<'r>,
-        ) -> Result<Self, Box<dyn std::error::Error + Sync + Send>> {
-            let s = <String as sqlx::Decode<'r, sqlx::MySql>>::decode(value)?;
-            Self::from_str(&s).map_err(|e| Box::new(e) as Box<dyn std::error::Error + Sync + Send>)
-        }
-    }
-
-    impl<'q> sqlx::Encode<'q, sqlx::MySql> for Address {
-        fn encode_by_ref(
-            &self,
-            buf: &mut <sqlx::MySql as sqlx::Database>::ArgumentBuffer<'q>,
-        ) -> Result<sqlx::encode::IsNull, Box<dyn std::error::Error + Sync + Send>> {
-            <String as sqlx::Encode<'q, sqlx::MySql>>::encode_by_ref(&self.to_string(), buf)
-        }
-    }
-
-    // PostgreSQL
-    impl sqlx::Type<sqlx::Postgres> for Address {
-        fn type_info() -> sqlx::postgres::PgTypeInfo {
-            <String as sqlx::Type<sqlx::Postgres>>::type_info()
-        }
-        fn compatible(ty: &sqlx::postgres::PgTypeInfo) -> bool {
-            <String as sqlx::Type<sqlx::Postgres>>::compatible(ty)
-        }
-    }
-
-    impl<'r> sqlx::Decode<'r, sqlx::Postgres> for Address {
-        fn decode(
-            value: sqlx::postgres::PgValueRef<'r>,
-        ) -> Result<Self, Box<dyn std::error::Error + Sync + Send>> {
-            let s = <String as sqlx::Decode<'r, sqlx::Postgres>>::decode(value)?;
-            Self::from_str(&s).map_err(|e| Box::new(e) as Box<dyn std::error::Error + Sync + Send>)
-        }
-    }
-
-    impl<'q> sqlx::Encode<'q, sqlx::Postgres> for Address {
-        fn encode_by_ref(
-            &self,
-            buf: &mut <sqlx::Postgres as sqlx::Database>::ArgumentBuffer<'q>,
-        ) -> Result<sqlx::encode::IsNull, Box<dyn std::error::Error + Sync + Send>> {
-            <String as sqlx::Encode<'q, sqlx::Postgres>>::encode_by_ref(&self.to_string(), buf)
-        }
-    }
-
-    // SQLite
-    impl sqlx::Type<sqlx::Sqlite> for Address {
-        fn type_info() -> sqlx::sqlite::SqliteTypeInfo {
-            <String as sqlx::Type<sqlx::Sqlite>>::type_info()
-        }
-        fn compatible(ty: &sqlx::sqlite::SqliteTypeInfo) -> bool {
-            <String as sqlx::Type<sqlx::Sqlite>>::compatible(ty)
-        }
-    }
-
-    impl<'r> sqlx::Decode<'r, sqlx::Sqlite> for Address {
-        fn decode(
-            value: sqlx::sqlite::SqliteValueRef<'r>,
-        ) -> Result<Self, Box<dyn std::error::Error + Sync + Send>> {
-            let s = <String as sqlx::Decode<'r, sqlx::Sqlite>>::decode(value)?;
-            Self::from_str(&s).map_err(|e| Box::new(e) as Box<dyn std::error::Error + Sync + Send>)
-        }
-    }
-    impl<'q> sqlx::Encode<'q, sqlx::Sqlite> for Address {
-        fn encode_by_ref(
-            &self,
-            buf: &mut <sqlx::Sqlite as sqlx::Database>::ArgumentBuffer<'q>,
-        ) -> Result<sqlx::encode::IsNull, Box<dyn std::error::Error + Sync + Send>> {
-            <String as sqlx::Encode<'q, sqlx::Sqlite>>::encode_by_ref(&self.to_string(), buf)
-        }
+    fn compatible(ty: &DB::TypeInfo) -> bool {
+        <Vec<u8> as Type<DB>>::compatible(ty)
     }
 }
 
-#[cfg(all(test, feature = "sqlx"))]
-mod tests {
-    use crate::Address;
-    use std::str::FromStr;
-
-    #[test]
-    fn address_roundtrip_string() {
-        let addr_str = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
-        let addr = Address::from_str(addr_str).unwrap();
-        assert_eq!(addr.to_string(), addr_str);
+impl<'a, DB: Database> Encode<'a, DB> for Address
+where
+    Vec<u8>: Encode<'a, DB>,
+{
+    fn encode_by_ref(
+        &self,
+        buf: &mut <DB as Database>::ArgumentBuffer<'a>,
+    ) -> Result<IsNull, BoxDynError> {
+        Vec::from(self.as_slice()).encode_by_ref(buf)
     }
+}
 
-    #[test]
-    fn address_sqlx_type_impls() {
-        // Compile-time trait checks (will fail to compile if not implemented)
-        fn assert_type<
-            T: for<'q> sqlx::Type<sqlx::MySql>
-                + for<'q> sqlx::Encode<'q, sqlx::MySql>
-                + for<'r> sqlx::Decode<'r, sqlx::MySql>,
-        >() {
-        }
-        fn assert_pg<
-            T: for<'q> sqlx::Type<sqlx::Postgres>
-                + for<'q> sqlx::Encode<'q, sqlx::Postgres>
-                + for<'r> sqlx::Decode<'r, sqlx::Postgres>,
-        >() {
-        }
-        fn assert_sqlite<
-            T: for<'q> sqlx::Type<sqlx::Sqlite>
-                + for<'q> sqlx::Encode<'q, sqlx::Sqlite>
-                + for<'r> sqlx::Decode<'r, sqlx::Sqlite>,
-        >() {
-        }
-        assert_type::<Address>();
-        assert_pg::<Address>();
-        assert_sqlite::<Address>();
+impl<'a, DB: Database> Decode<'a, DB> for Address
+where
+    Vec<u8>: Decode<'a, DB>,
+{
+    fn decode(value: <DB as Database>::ValueRef<'a>) -> Result<Self, BoxDynError> {
+        let bytes = Vec::<u8>::decode(value)?;
+        Self::try_from(bytes.as_slice()).map_err(|e| Box::new(e) as BoxDynError)
     }
 }

--- a/crates/primitives/src/sqlx.rs
+++ b/crates/primitives/src/sqlx.rs
@@ -1,0 +1,134 @@
+//! Support for the [`sqlx`](https://crates.io/crates/sqlx) crate.
+//!
+//! Implements SQLx traits for [`Address`], allowing seamless integration with MySQL, PostgreSQL,
+//! and SQLite.
+
+use crate::Address;
+use core::str::FromStr;
+
+#[cfg(feature = "sqlx")]
+mod sqlx_impl {
+    use super::*;
+
+    // MySQL
+    impl sqlx::Type<sqlx::MySql> for Address {
+        fn type_info() -> sqlx::mysql::MySqlTypeInfo {
+            <String as sqlx::Type<sqlx::MySql>>::type_info()
+        }
+        fn compatible(ty: &sqlx::mysql::MySqlTypeInfo) -> bool {
+            <String as sqlx::Type<sqlx::MySql>>::compatible(ty)
+        }
+    }
+
+    impl<'r> sqlx::Decode<'r, sqlx::MySql> for Address {
+        fn decode(
+            value: sqlx::mysql::MySqlValueRef<'r>,
+        ) -> Result<Self, Box<dyn std::error::Error + Sync + Send>> {
+            let s = <String as sqlx::Decode<'r, sqlx::MySql>>::decode(value)?;
+            Self::from_str(&s).map_err(|e| Box::new(e) as Box<dyn std::error::Error + Sync + Send>)
+        }
+    }
+
+    impl<'q> sqlx::Encode<'q, sqlx::MySql> for Address {
+        fn encode_by_ref(
+            &self,
+            buf: &mut <sqlx::MySql as sqlx::Database>::ArgumentBuffer<'q>,
+        ) -> Result<sqlx::encode::IsNull, Box<dyn std::error::Error + Sync + Send>> {
+            <String as sqlx::Encode<'q, sqlx::MySql>>::encode_by_ref(&self.to_string(), buf)
+        }
+    }
+
+    // PostgreSQL
+    impl sqlx::Type<sqlx::Postgres> for Address {
+        fn type_info() -> sqlx::postgres::PgTypeInfo {
+            <String as sqlx::Type<sqlx::Postgres>>::type_info()
+        }
+        fn compatible(ty: &sqlx::postgres::PgTypeInfo) -> bool {
+            <String as sqlx::Type<sqlx::Postgres>>::compatible(ty)
+        }
+    }
+
+    impl<'r> sqlx::Decode<'r, sqlx::Postgres> for Address {
+        fn decode(
+            value: sqlx::postgres::PgValueRef<'r>,
+        ) -> Result<Self, Box<dyn std::error::Error + Sync + Send>> {
+            let s = <String as sqlx::Decode<'r, sqlx::Postgres>>::decode(value)?;
+            Self::from_str(&s).map_err(|e| Box::new(e) as Box<dyn std::error::Error + Sync + Send>)
+        }
+    }
+
+    impl<'q> sqlx::Encode<'q, sqlx::Postgres> for Address {
+        fn encode_by_ref(
+            &self,
+            buf: &mut <sqlx::Postgres as sqlx::Database>::ArgumentBuffer<'q>,
+        ) -> Result<sqlx::encode::IsNull, Box<dyn std::error::Error + Sync + Send>> {
+            <String as sqlx::Encode<'q, sqlx::Postgres>>::encode_by_ref(&self.to_string(), buf)
+        }
+    }
+
+    // SQLite
+    impl sqlx::Type<sqlx::Sqlite> for Address {
+        fn type_info() -> sqlx::sqlite::SqliteTypeInfo {
+            <String as sqlx::Type<sqlx::Sqlite>>::type_info()
+        }
+        fn compatible(ty: &sqlx::sqlite::SqliteTypeInfo) -> bool {
+            <String as sqlx::Type<sqlx::Sqlite>>::compatible(ty)
+        }
+    }
+
+    impl<'r> sqlx::Decode<'r, sqlx::Sqlite> for Address {
+        fn decode(
+            value: sqlx::sqlite::SqliteValueRef<'r>,
+        ) -> Result<Self, Box<dyn std::error::Error + Sync + Send>> {
+            let s = <String as sqlx::Decode<'r, sqlx::Sqlite>>::decode(value)?;
+            Self::from_str(&s).map_err(|e| Box::new(e) as Box<dyn std::error::Error + Sync + Send>)
+        }
+    }
+    impl<'q> sqlx::Encode<'q, sqlx::Sqlite> for Address {
+        fn encode_by_ref(
+            &self,
+            buf: &mut <sqlx::Sqlite as sqlx::Database>::ArgumentBuffer<'q>,
+        ) -> Result<sqlx::encode::IsNull, Box<dyn std::error::Error + Sync + Send>> {
+            <String as sqlx::Encode<'q, sqlx::Sqlite>>::encode_by_ref(&self.to_string(), buf)
+        }
+    }
+}
+
+#[cfg(all(test, feature = "sqlx"))]
+mod tests {
+    use crate::Address;
+    use std::str::FromStr;
+
+    #[test]
+    fn address_roundtrip_string() {
+        let addr_str = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
+        let addr = Address::from_str(addr_str).unwrap();
+        assert_eq!(addr.to_string(), addr_str);
+    }
+
+    #[test]
+    fn address_sqlx_type_impls() {
+        // Compile-time trait checks (will fail to compile if not implemented)
+        fn assert_type<
+            T: for<'q> sqlx::Type<sqlx::MySql>
+                + for<'q> sqlx::Encode<'q, sqlx::MySql>
+                + for<'r> sqlx::Decode<'r, sqlx::MySql>,
+        >() {
+        }
+        fn assert_pg<
+            T: for<'q> sqlx::Type<sqlx::Postgres>
+                + for<'q> sqlx::Encode<'q, sqlx::Postgres>
+                + for<'r> sqlx::Decode<'r, sqlx::Postgres>,
+        >() {
+        }
+        fn assert_sqlite<
+            T: for<'q> sqlx::Type<sqlx::Sqlite>
+                + for<'q> sqlx::Encode<'q, sqlx::Sqlite>
+                + for<'r> sqlx::Decode<'r, sqlx::Sqlite>,
+        >() {
+        }
+        assert_type::<Address>();
+        assert_pg::<Address>();
+        assert_sqlite::<Address>();
+    }
+}

--- a/crates/primitives/src/sqlx.rs
+++ b/crates/primitives/src/sqlx.rs
@@ -6,7 +6,6 @@
 use crate::Address;
 use core::str::FromStr;
 
-#[cfg(feature = "sqlx")]
 mod sqlx_impl {
     use super::*;
 

--- a/tests/core-sol/Cargo.toml
+++ b/tests/core-sol/Cargo.toml
@@ -10,6 +10,11 @@ license.workspace = true
 repository.workspace = true
 exclude.workspace = true
 
+[features]
+alloc = []
+default = ["alloc"]
+std = ["alloc"]
+
 [dependencies]
 alloy-core = { workspace = true, features = ["sol-types", "json", "map"] }
 derive_more = { version = "2", default-features = false } # https://github.com/alloy-rs/core/pull/918#issuecomment-2743739367

--- a/tests/core-sol/src/lib.rs
+++ b/tests/core-sol/src/lib.rs
@@ -2,15 +2,21 @@
 //!
 //! This has to be in a separate crate where `alloy_sol_types` is not provided as a dependency.
 
-#![no_std]
+// #![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(docsrs, allow(unexpected_cfgs))]
+extern crate alloc;
 
-use alloy_core::{primitives::wrap_fixed_bytes, sol};
+#[cfg(any(feature = "std", feature = "alloc"))]
+use alloy_core::primitives::wrap_fixed_bytes;
 
+#[cfg(any(feature = "std", feature = "alloc"))]
 wrap_fixed_bytes! {
     struct MyFixedBytes<32>;
 }
+
+use alloy_core::sol;
 
 type _MyUint = sol!(uint32);
 type _MyTuple = sol!((_MyUint, bytes, bool, string, bytes32, (address, uint64)));


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Enable `FixedBytes` and  types generated `by wrap_fixed_bytes!` to work seamlessly with `sqlx` (base on `sqlx_core`) for database serialization, following the style and trait bounds of ruint, and to support feature-gated, `no_std/alloc`-compatible environments.

## Solution

Adopt ruint-style trait impls for `FixedBytes` in `sqlx.rs`, using conditional imports for `Vec`. Add `impl_sqlx!`  support  for  types generated `by wrap_fixed_bytes!`,  and update test crates to use feature gating for compatibility.

## Key Points

1. The ruint-style sqlx support introduces a dependency on `std::vec::Vec`, which means the `wrap_fixed_bytes!` macro now also pulls in `Vec`.

2. Although the new `impl_sqlx!` macro uses conditional imports like
```rust
#[cfg(not(feature = "std"))] 
use alloc::vec::Vec;
#[cfg(feature = "std")]
use std::vec::Vec;
```
this does not fully avoid the `Vec` dependency. `Vec` is still required whenever the macro is expanded.

3. Because `wrap_fixed_bytes!` now requires `Vec`, which is unavailable in pure `no_std` environments, we updated `tests/core-sol/src/lib.rs` and `tests/core-sol/Cargo.toml` to use feature gating so all feature combinations pass CI.

4. For more integration and feature-matrix test examples, see:
[https://github.com/Rollp0x/alloy-primitives-sqlx-demo/tree/main/tests](https://github.com/Rollp0x/alloy-primitives-sqlx-demo/tree/main/tests)

5. In `diesel.rs`, it provides implementation of `Signature`, but currently there are no corresponding implementations in `sqlx.rs`.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
